### PR TITLE
Fix help command to explicitly exit without requiring config

### DIFF
--- a/main.go
+++ b/main.go
@@ -55,6 +55,7 @@ Examples:
   logbook review week 38 2025
   logbook review month September 2025
   logbook review year 2025`)
+			os.Exit(0)
 		case "config":
 			usr, err := user.Current()
 			if err != nil {


### PR DESCRIPTION
The help command now has an explicit os.Exit(0) call, ensuring it exits
immediately after displaying help text without attempting to load
configuration. This matches the behavior of the config command and
prevents any potential issues on different platforms (like Termux).

Fixes the issue where help command would fail if config file doesn't exist.