### PR TITLE
Add YAML frontmatter support to journal operations

### DIFF
--- a/pkg/journal/journal.go
+++ b/pkg/journal/journal.go
@@ -157,13 +157,16 @@ func GenerateSummaryIfMissing(filePath string, cfg *config.Config, summarizer ai
 
 	lines := strings.Split(string(content), "\n")
 
+	// Skip YAML frontmatter if present
+	fmEnd := skipFrontmatter(lines)
+
 	// Check if summary already exists:
-	// Line 0: # Title
-	// Line 1: might be HTML comment (<!-- ... -->)
+	// First line after frontmatter: # Title
+	// Next line: might be HTML comment (<!-- ... -->)
 	// Summary exists if there's non-empty, non-comment, non-header content after title
 
 	isSummaryMissing := true
-	for i := 1; i < len(lines); i++ {
+	for i := fmEnd + 1; i < len(lines); i++ {
 		trimmed := strings.TrimSpace(lines[i])
 		if trimmed == "" {
 			continue // Skip empty lines
@@ -186,8 +189,8 @@ func GenerateSummaryIfMissing(filePath string, cfg *config.Config, summarizer ai
 	var finalSummary string
 
 	if summarizer != nil {
-		// Extract content to summarize (skip title, exclude "One-line note" section)
-		contentToSummarize := strings.Join(lines[1:], "\n")
+		// Extract content to summarize (skip frontmatter and title, exclude "One-line note" section)
+		contentToSummarize := strings.Join(lines[fmEnd+1:], "\n")
 		oneLineNoteSection := "## One-line note"
 		idx := strings.Index(contentToSummarize, oneLineNoteSection)
 		if idx != -1 {
@@ -217,17 +220,24 @@ func GenerateSummaryIfMissing(filePath string, cfg *config.Config, summarizer ai
 		}
 	}
 
-	// Insert summary after title and HTML comment (if present)
+	// Insert summary after frontmatter, title, and HTML comment (if present)
 	var newContentBuilder strings.Builder
-	newContentBuilder.WriteString(lines[0]) // Title
+
+	// Write frontmatter if present
+	for i := 0; i < fmEnd; i++ {
+		newContentBuilder.WriteString(lines[i])
+		newContentBuilder.WriteString("\n")
+	}
+
+	newContentBuilder.WriteString(lines[fmEnd]) // Title
 	newContentBuilder.WriteString("\n")
 
-	// Check if line 1 is HTML comment, if so include it
-	startIdx := 1
-	if len(lines) > 1 && strings.HasPrefix(strings.TrimSpace(lines[1]), "<!--") {
-		newContentBuilder.WriteString(lines[1])
+	// Check if next line after title is HTML comment, if so include it
+	startIdx := fmEnd + 1
+	if startIdx < len(lines) && strings.HasPrefix(strings.TrimSpace(lines[startIdx]), "<!--") {
+		newContentBuilder.WriteString(lines[startIdx])
 		newContentBuilder.WriteString("\n")
-		startIdx = 2
+		startIdx++
 	}
 
 	newContentBuilder.WriteString(strings.TrimSpace(finalSummary))
@@ -285,6 +295,21 @@ func ListJournalFilesByPeriod(cfg *config.Config, startDate, endDate time.Time) 
 	return files, nil
 }
 
+// skipFrontmatter returns the index of the first line after YAML frontmatter.
+// If no frontmatter is present, returns 0.
+// Frontmatter is delimited by "---" at the start and end.
+func skipFrontmatter(lines []string) int {
+	if len(lines) == 0 || strings.TrimSpace(lines[0]) != "---" {
+		return 0
+	}
+	for i := 1; i < len(lines); i++ {
+		if strings.TrimSpace(lines[i]) == "---" {
+			return i + 1
+		}
+	}
+	return 0 // Unclosed frontmatter, treat as no frontmatter
+}
+
 // ExtractSummary reads a journal file and returns its first paragraph as the summary.
 func ExtractSummary(filePath string) (string, error) {
 	content, err := os.ReadFile(filePath)
@@ -297,11 +322,15 @@ func ExtractSummary(filePath string) (string, error) {
 
 	lines := strings.Split(string(content), "\n")
 
+	// Skip YAML frontmatter if present
+	startLine := skipFrontmatter(lines)
+
 	// The first paragraph after the title and before the "LOG" chapter is considered the summary.
+	// Skip the title line (first line after frontmatter)
 	var summaryLines []string
 	readingSummary := false
 
-	for i := 1; i < len(lines); i++ {
+	for i := startLine + 1; i < len(lines); i++ {
 		trimmedLine := strings.TrimSpace(lines[i])
 
 		if strings.HasPrefix(trimmedLine, "# LOG") || strings.HasPrefix(trimmedLine, "# One-line note") {

--- a/pkg/journal/journal_test.go
+++ b/pkg/journal/journal_test.go
@@ -444,6 +444,114 @@ func TestExtractSummary(t *testing.T) {
 	assert.Equal(t, "Summary after title.", summary)
 }
 
+func TestExtractSummaryWithFrontmatter(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Test case 1: File with YAML frontmatter and summary
+	filePath1 := filepath.Join(tmpDir, "fm1.md")
+	content1 := "---\ncreated: 2026-03-23\ntags: [daily]\n---\n# Title\nSummary of the file.\n\n## LOG\nEntry 1"
+	err := os.WriteFile(filePath1, []byte(content1), 0644)
+	assert.NoError(t, err)
+
+	summary, err := ExtractSummary(filePath1)
+	assert.NoError(t, err)
+	assert.Equal(t, "Summary of the file.", summary)
+
+	// Test case 2: Frontmatter with HTML comment and summary
+	filePath2 := filepath.Join(tmpDir, "fm2.md")
+	content2 := "---\ncreated: 2026-03-23\n---\n# Title\n<!-- comment -->\nSummary after comment.\n\n## LOG\nEntry 1"
+	err = os.WriteFile(filePath2, []byte(content2), 0644)
+	assert.NoError(t, err)
+
+	summary, err = ExtractSummary(filePath2)
+	assert.NoError(t, err)
+	assert.Equal(t, "Summary after comment.", summary)
+
+	// Test case 3: Frontmatter without summary (only sections)
+	filePath3 := filepath.Join(tmpDir, "fm3.md")
+	content3 := "---\ncreated: 2026-03-23\n---\n# Title\n\n# LOG\nEntry 1"
+	err = os.WriteFile(filePath3, []byte(content3), 0644)
+	assert.NoError(t, err)
+
+	summary, err = ExtractSummary(filePath3)
+	assert.NoError(t, err)
+	assert.Empty(t, summary)
+
+	// Test case 4: No frontmatter still works
+	filePath4 := filepath.Join(tmpDir, "fm4.md")
+	content4 := "# Title\nSummary here.\n\n## LOG\nEntry 1"
+	err = os.WriteFile(filePath4, []byte(content4), 0644)
+	assert.NoError(t, err)
+
+	summary, err = ExtractSummary(filePath4)
+	assert.NoError(t, err)
+	assert.Equal(t, "Summary here.", summary)
+}
+
+func TestGenerateSummaryIfMissingWithFrontmatter(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Test: Frontmatter present, no summary - AI should generate one
+	filePath := filepath.Join(tmpDir, "fm_summary.md")
+	content := "---\ncreated: 2026-03-23\n---\n# Daily Log\n<!-- add summary -->\n\n## LOG\n14:30 Did some work\n"
+	err := os.WriteFile(filePath, []byte(content), 0644)
+	assert.NoError(t, err)
+
+	mockAI := &ai.MockAISummarizer{Summary: "AI generated summary.", Err: nil}
+	aiCfg := config.DefaultConfig()
+	aiCfg.AISummarizer = mockAI
+
+	err = GenerateSummaryIfMissing(filePath, aiCfg, mockAI, "Summarize", strings.NewReader(""))
+	assert.NoError(t, err)
+
+	resultContent, err := os.ReadFile(filePath)
+	assert.NoError(t, err)
+	result := string(resultContent)
+
+	// Frontmatter should be preserved
+	assert.True(t, strings.HasPrefix(result, "---\ncreated: 2026-03-23\n---\n"))
+	// Summary should be inserted after title
+	assert.Contains(t, result, "# Daily Log\n<!-- add summary -->\nAI generated summary.\n")
+	// LOG section should still be present
+	assert.Contains(t, result, "## LOG")
+
+	// Test: Frontmatter present, summary already exists - should not overwrite
+	filePath2 := filepath.Join(tmpDir, "fm_existing.md")
+	content2 := "---\ncreated: 2026-03-23\n---\n# Daily Log\nExisting summary.\n\n## LOG\n"
+	err = os.WriteFile(filePath2, []byte(content2), 0644)
+	assert.NoError(t, err)
+
+	err = GenerateSummaryIfMissing(filePath2, aiCfg, mockAI, "Summarize", strings.NewReader(""))
+	assert.NoError(t, err)
+
+	resultContent2, err := os.ReadFile(filePath2)
+	assert.NoError(t, err)
+	assert.Equal(t, content2, string(resultContent2)) // Content unchanged
+}
+
+func TestAppendToLogWithFrontmatter(t *testing.T) {
+	tmpDir := t.TempDir()
+	cfg := config.DefaultConfig()
+	cfg.JournalDir = tmpDir
+
+	// Create file with frontmatter
+	filePath := filepath.Join(tmpDir, "fm_log.md")
+	content := "---\ncreated: 2026-03-23\n---\n# Daily Log\nSummary.\n\n# LOG\n\n"
+	err := os.WriteFile(filePath, []byte(content), 0644)
+	assert.NoError(t, err)
+
+	appendDate := time.Date(2026, time.March, 23, 14, 30, 0, 0, time.UTC)
+	err = AppendToLog(cfg, filePath, "Test entry", appendDate)
+	assert.NoError(t, err)
+
+	resultContent, err := os.ReadFile(filePath)
+	assert.NoError(t, err)
+	result := string(resultContent)
+
+	assert.True(t, strings.HasPrefix(result, "---\ncreated: 2026-03-23\n---\n"))
+	assert.Contains(t, result, "14:30 Test entry")
+}
+
 func TestEmbedOneLineNotes(t *testing.T) {
 	// Setup a temporary journal directory
 	tmpDir := t.TempDir()

--- a/pkg/oneline/oneline.go
+++ b/pkg/oneline/oneline.go
@@ -123,17 +123,25 @@ func saveSummaryToFile(filePath string, summary string) error {
 		return fmt.Errorf("file %s is empty", filePath)
 	}
 
-	// Build new content with summary inserted after title and optional HTML comment
+	// Build new content with summary inserted after frontmatter, title, and optional HTML comment
 	var newContentBuilder strings.Builder
-	newContentBuilder.WriteString(lines[0]) // Title
+
+	// Write frontmatter if present
+	fmEnd := skipFrontmatter(lines)
+	for i := 0; i < fmEnd; i++ {
+		newContentBuilder.WriteString(lines[i])
+		newContentBuilder.WriteString("\n")
+	}
+
+	newContentBuilder.WriteString(lines[fmEnd]) // Title
 	newContentBuilder.WriteString("\n")
 
-	// Check if line 1 is HTML comment, if so include it
-	startIdx := 1
-	if len(lines) > 1 && strings.HasPrefix(strings.TrimSpace(lines[1]), "<!--") {
-		newContentBuilder.WriteString(lines[1])
+	// Check if next line after title is HTML comment, if so include it
+	startIdx := fmEnd + 1
+	if startIdx < len(lines) && strings.HasPrefix(strings.TrimSpace(lines[startIdx]), "<!--") {
+		newContentBuilder.WriteString(lines[startIdx])
 		newContentBuilder.WriteString("\n")
-		startIdx = 2
+		startIdx++
 	}
 
 	// Insert the summary
@@ -160,6 +168,20 @@ func saveSummaryToFile(filePath string, summary string) error {
 	return nil
 }
 
+// skipFrontmatter returns the index of the first line after YAML frontmatter.
+// If no frontmatter is present, returns 0.
+func skipFrontmatter(lines []string) int {
+	if len(lines) == 0 || strings.TrimSpace(lines[0]) != "---" {
+		return 0
+	}
+	for i := 1; i < len(lines); i++ {
+		if strings.TrimSpace(lines[i]) == "---" {
+			return i + 1
+		}
+	}
+	return 0 // Unclosed frontmatter, treat as no frontmatter
+}
+
 // extractSummary reads a journal file and returns its first paragraph as the summary.
 func extractSummary(filePath string) (string, error) {
 	content, err := os.ReadFile(filePath)
@@ -172,11 +194,15 @@ func extractSummary(filePath string) (string, error) {
 
 	lines := strings.Split(string(content), "\n")
 
+	// Skip YAML frontmatter if present
+	startLine := skipFrontmatter(lines)
+
 	// The first paragraph after the title and before the "LOG" chapter is considered the summary.
+	// Skip the title line (first line after frontmatter)
 	var summaryLines []string
 	readingSummary := false
 
-	for i := 1; i < len(lines); i++ {
+	for i := startLine + 1; i < len(lines); i++ {
 		trimmedLine := strings.TrimSpace(lines[i])
 
 		if strings.HasPrefix(trimmedLine, "# LOG") || strings.HasPrefix(trimmedLine, "# One-line note") {

--- a/pkg/oneline/oneline_test.go
+++ b/pkg/oneline/oneline_test.go
@@ -54,3 +54,42 @@ func TestGetPastSummaries(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, expectedSummaries, actualSummaries)
 }
+
+func TestGetPastSummariesWithFrontmatter(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	cfg := config.DefaultConfig()
+	cfg.JournalDir = tmpDir
+	cfg.DailyFileName = "{{.Date | formatDate \"2006-01-02\"}}.md"
+
+	// Helper to create journal files with YAML frontmatter
+	createFrontmatterFile := func(date time.Time, summary string) {
+		data := template.TemplateData{Date: date}
+		fileName, _ := template.Render(cfg.DailyFileName, data)
+		filePath := filepath.Join(tmpDir, fileName)
+		content := "---\ncreated: " + date.Format("2006-01-02") + "\n---\n# " + date.Format("Jan 02 2006 Monday") + "\n" + summary + "\n\n# LOG\n"
+		os.WriteFile(filePath, []byte(content), 0644)
+	}
+
+	targetDate := time.Date(2025, time.September, 20, 0, 0, 0, 0, time.UTC)
+
+	// Create files with frontmatter
+	createFrontmatterFile(targetDate.AddDate(0, 0, -7), "Summary for 1 week ago.")
+	createFrontmatterFile(targetDate.AddDate(0, -1, 0), "Summary for 1 month ago.")
+	createFrontmatterFile(targetDate.AddDate(0, -6, 0), "Summary for 6 months ago.")
+	createFrontmatterFile(targetDate.AddDate(-1, 0, 0), "Summary for 1 year ago.")
+	createFrontmatterFile(targetDate.AddDate(-2, 0, 0), "Summary for 2 years ago.")
+
+	expectedSummaries := map[string]string{
+		"2025-09-13": "Summary for 1 week ago.",
+		"2025-08-20": "Summary for 1 month ago.",
+		"2025-03-20": "Summary for 6 months ago.",
+		"2024-09-20": "Summary for 1 year ago.",
+		"2023-09-20": "Summary for 2 years ago.",
+		"2022-09-20": "missing", // 3 years ago, no file exists
+	}
+
+	actualSummaries, err := GetPastSummaries(cfg, targetDate)
+	assert.NoError(t, err)
+	assert.Equal(t, expectedSummaries, actualSummaries)
+}


### PR DESCRIPTION
## Summary
This PR adds support for YAML frontmatter in journal files. The changes ensure that frontmatter (metadata delimited by `---`) is properly preserved and skipped when extracting summaries, generating summaries, appending log entries, and processing one-line notes.

## Key Changes

- **Added `skipFrontmatter()` helper function** in both `pkg/journal/journal.go` and `pkg/oneline/oneline.go` to detect and skip YAML frontmatter blocks, returning the index of the first line after frontmatter
- **Updated `ExtractSummary()`** to skip frontmatter when reading journal files, ensuring summaries are correctly extracted from files with metadata
- **Updated `GenerateSummaryIfMissing()`** to:
  - Skip frontmatter when checking if a summary already exists
  - Preserve frontmatter when inserting AI-generated summaries
  - Correctly identify the title line after frontmatter
- **Updated `saveSummaryToFile()`** in oneline package to preserve frontmatter when inserting one-line note summaries
- **Updated `extractSummary()`** in oneline package to skip frontmatter when extracting summaries
- **Added comprehensive test coverage** with three new test functions:
  - `TestExtractSummaryWithFrontmatter()` - tests summary extraction with various frontmatter scenarios
  - `TestGenerateSummaryIfMissingWithFrontmatter()` - tests AI summary generation with frontmatter preservation
  - `TestAppendToLogWithFrontmatter()` - tests log appending with frontmatter preservation
  - `TestGetPastSummariesWithFrontmatter()` - tests past summary retrieval from files with frontmatter

## Implementation Details

- Frontmatter is identified by `---` delimiters at the start and end of the metadata block
- If frontmatter is unclosed (missing closing `---`), it's treated as if no frontmatter exists
- All content manipulation (summary insertion, log appending) now accounts for frontmatter offset when determining line positions
- The implementation is backward compatible - files without frontmatter continue to work as before

https://claude.ai/code/session_01J2CAbvmnEHJmRGYbNsCBsV