### PR TITLE
Support Obsidian/Moment.js date format tokens in templates

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -128,6 +128,9 @@ pkg/
 **Template Engine (`pkg/template/`)**
 - Uses Go's `text/template` package
 - Custom functions: `formatDate` for date formatting, `formatTime` for time formatting
+- Date format strings use **Obsidian/Moment.js tokens** (e.g., `YYYY-MM-DD`, `HH:mm`) instead of Go's reference-time format
+- Supported tokens: `YYYY`, `YY`, `MMMM`, `MMM`, `MM`, `M`, `DD`, `D`, `dddd`, `ddd`, `HH`, `hh`, `h`, `mm`, `m`, `ss`, `s`, `A`, `a`
+- Use `[text]` brackets to escape literal text in format strings
 - Template data includes: `Date`, `Time`, `Summary`, `Entry` fields
 - Used for rendering file names, daily templates, and log entries
 
@@ -140,7 +143,8 @@ pkg/
    - Reviews rely on summaries from daily files
 
 2. **Date Handling**:
-   - Daily file names use template: `{{.Date | formatDate "2006-01-02"}}.md`
+   - Date format strings use Obsidian/Moment.js tokens (e.g., `YYYY-MM-DD` instead of Go's `2006-01-02`)
+   - Daily file names use template: `{{.Date | formatDate "YYYY-MM-DD"}}.md`
    - Reviews use ISO week calculation for week boundaries
    - One-line notes show summaries from: 1 week ago, 1 month ago, 6 months ago, and all past years (dynamically)
 
@@ -162,14 +166,14 @@ All PRD requirements have been implemented:
 2. **One-Line Notes Integration** (Req #17-20): ✅ Fully integrated into `CreateDailyJournalFile` - automatically embeds historical summaries
 3. **One-Line Past Years** (Req #18): ✅ Dynamically checks all past years (up to 3 years back) until no entries found
 4. **One-Line Periods**: ✅ Includes 1 week ago, 1 month ago, 6 months ago, and all past years
-5. **LOG Entry Template** (Req #5): ✅ Now configurable via `log_entry_template` config setting (default: `{{.Time | formatTime "15:04"}} {{.Entry}}`)
+5. **LOG Entry Template** (Req #5): ✅ Now configurable via `log_entry_template` config setting (default: `{{.Time | formatTime "HH:mm"}} {{.Entry}}`)
 
 ## Configuration File Location
 
 The config file is always at `~/.config/logbook/config.toml` (XDG config directory). The default config includes:
 - `journal_dir`: `~/.logbook/journal`
 - `daily_template`: Includes "## One-line note" section at the end
-- `log_entry_template`: `{{.Time | formatTime "15:04"}} {{.Entry}}` (configurable timestamp and entry format)
+- `log_entry_template`: `{{.Time | formatTime "HH:mm"}} {{.Entry}}` (configurable timestamp and entry format)
 - `ai_enabled`: `false` (must be explicitly enabled)
 - `ai_command`: Command template with `{PROMPT}` and `{TEXT}` placeholders
   - Example: `gemini --prompt '{PROMPT} {TEXT}'`

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -35,16 +35,16 @@ func DefaultConfig() *Config {
 
 	return &Config{
 		JournalDir:        filepath.Join(homeDir, ".logbook", "journal"),
-		DailyFileName:     "{{.Date | formatDate \"2006-01-02\"}}.md",
-		DailyTemplate:     "# {{.Date | formatDate \"Jan 02 2006 Monday\"}}\n<!-- add today summary below this line. If missing, the AI will generate one for you according to configuration file -->\n\n# One-line note\n\n# LOG\n\n",
-		LogEntryTemplate:  "{{.Time | formatTime \"15:04\"}} {{.Entry}}",
+		DailyFileName:     "{{.Date | formatDate \"YYYY-MM-DD\"}}.md",
+		DailyTemplate:     "# {{.Date | formatDate \"MMM DD YYYY dddd\"}}\n<!-- add today summary below this line. If missing, the AI will generate one for you according to configuration file -->\n\n# One-line note\n\n# LOG\n\n",
+		LogEntryTemplate:  "{{.Time | formatTime \"HH:mm\"}} {{.Entry}}",
 		AIEnabled:         false,
 		AICommand:         "", // Example: "gemini --prompt '{PROMPT} {TEXT}'" or "claude --text '{TEXT}' --instructions '{PROMPT}'"
 		AIPrompt:          "Write a summary of the note at the given file. Use 1st person and a simple language. Use 200 characters or less",
 		ReviewWeekPrompt:  "Write a summary of the weekly review using the same Language. Use 1st person and a simple language. Use 200 characters or less.",
 		ReviewMonthPrompt: "Write a summary of the monthly review. Use 1st person and a simple language. Use 200 characters or less.",
 		ReviewYearPrompt:  "Write a summary of the yearly review. Use 1st person and a simple language. Use 200 characters or less.",
-		OneLineTemplate:   "{{.Date | formatDate \"2006-01-02\"}}: {{.Summary}}",
+		OneLineTemplate:   "{{.Date | formatDate \"YYYY-MM-DD\"}}: {{.Summary}}",
 	}
 }
 

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -18,15 +18,15 @@ func TestDefaultConfig(t *testing.T) {
 	}
 
 	assert.Equal(t, filepath.Join(homeDir, ".logbook", "journal"), cfg.JournalDir)
-	assert.Equal(t, "{{.Date | formatDate \"2006-01-02\"}}.md", cfg.DailyFileName)
-	assert.Equal(t, "# {{.Date | formatDate \"Jan 02 2006 Monday\"}}\n<!-- add today summary below this line. If missing, the AI will generate one for you according to configuration file -->\n\n# One-line note\n\n# LOG\n\n", cfg.DailyTemplate)
-	assert.Equal(t, "{{.Time | formatTime \"15:04\"}} {{.Entry}}", cfg.LogEntryTemplate)
+	assert.Equal(t, "{{.Date | formatDate \"YYYY-MM-DD\"}}.md", cfg.DailyFileName)
+	assert.Equal(t, "# {{.Date | formatDate \"MMM DD YYYY dddd\"}}\n<!-- add today summary below this line. If missing, the AI will generate one for you according to configuration file -->\n\n# One-line note\n\n# LOG\n\n", cfg.DailyTemplate)
+	assert.Equal(t, "{{.Time | formatTime \"HH:mm\"}} {{.Entry}}", cfg.LogEntryTemplate)
 	assert.False(t, cfg.AIEnabled)
 	assert.Equal(t, "Write a summary of the note at the given file. Use 1st person and a simple language. Use 200 characters or less", cfg.AIPrompt)
 	assert.Equal(t, "Write a summary of the weekly review using the same Language. Use 1st person and a simple language. Use 200 characters or less.", cfg.ReviewWeekPrompt)
 	assert.Equal(t, "Write a summary of the monthly review. Use 1st person and a simple language. Use 200 characters or less.", cfg.ReviewMonthPrompt)
 	assert.Equal(t, "Write a summary of the yearly review. Use 1st person and a simple language. Use 200 characters or less.", cfg.ReviewYearPrompt)
-	assert.Equal(t, "{{.Date | formatDate \"2006-01-02\"}}: {{.Summary}}", cfg.OneLineTemplate)
+	assert.Equal(t, "{{.Date | formatDate \"YYYY-MM-DD\"}}: {{.Summary}}", cfg.OneLineTemplate)
 }
 
 func TestLoadConfig(t *testing.T) {
@@ -36,10 +36,10 @@ func TestLoadConfig(t *testing.T) {
 	expectedConfig := &Config{
 		JournalDir:      "/tmp/myjournal",
 		DailyFileName:   "DD-MM-YYYY.md",
-		DailyTemplate:   "## {{.Date | formatDate \"Monday, January 2, 2006\"}}\n",
+		DailyTemplate:   "## {{.Date | formatDate \"dddd, MMMM D, YYYY\"}}\n",
 		AIEnabled:       true,
 		AIPrompt:        "Summarize this entry.",
-		OneLineTemplate: "{{.Date | formatDate \"01/02\"}} - {{.Summary}}",
+		OneLineTemplate: "{{.Date | formatDate \"MM/DD\"}} - {{.Summary}}",
 	}
 
 	err := SaveConfig(tmpfile, expectedConfig)
@@ -80,16 +80,16 @@ func TestSaveConfig(t *testing.T) {
 	assert.NoError(t, err)
 
 	expectedContent := `journal_dir = "/path/to/journal"
-daily_file_name = "{{.Date | formatDate \"2006-01-02\"}}.md"
-daily_template = "# {{.Date | formatDate \"Jan 02 2006 Monday\"}}\n<!-- add today summary below this line. If missing, the AI will generate one for you according to configuration file -->\n\n# One-line note\n\n# LOG\n\n"
-log_entry_template = "{{.Time | formatTime \"15:04\"}} {{.Entry}}"
+daily_file_name = "{{.Date | formatDate \"YYYY-MM-DD\"}}.md"
+daily_template = "# {{.Date | formatDate \"MMM DD YYYY dddd\"}}\n<!-- add today summary below this line. If missing, the AI will generate one for you according to configuration file -->\n\n# One-line note\n\n# LOG\n\n"
+log_entry_template = "{{.Time | formatTime \"HH:mm\"}} {{.Entry}}"
 ai_enabled = true
 ai_command = ""
 ai_prompt = "Write a summary of the note at the given file. Use 1st person and a simple language. Use 200 characters or less"
 review_week_prompt = "Write a summary of the weekly review using the same Language. Use 1st person and a simple language. Use 200 characters or less."
 review_month_prompt = "Write a summary of the monthly review. Use 1st person and a simple language. Use 200 characters or less."
 review_year_prompt = "Write a summary of the yearly review. Use 1st person and a simple language. Use 200 characters or less."
-one_line_template = "{{.Date | formatDate \"2006-01-02\"}}: {{.Summary}}"
+one_line_template = "{{.Date | formatDate \"YYYY-MM-DD\"}}: {{.Summary}}"
 `
 	assert.Equal(t, expectedContent, string(content))
 

--- a/pkg/journal/journal_test.go
+++ b/pkg/journal/journal_test.go
@@ -32,7 +32,7 @@ func TestCreateDailyJournalFile(t *testing.T) {
 
 	cfg := config.DefaultConfig()
 	cfg.JournalDir = tmpDir
-	cfg.DailyFileName = "{{.Date | formatDate \"2006-01-02\"}}.md"
+	cfg.DailyFileName = "{{.Date | formatDate \"YYYY-MM-DD\"}}.md"
 
 	// Test case 1: File does not exist, should create successfully
 
@@ -75,7 +75,7 @@ func TestCreateDailyJournalFile(t *testing.T) {
 	assert.FileExists(t, filePath)
 
 	// Test case 6: Custom file naming convention
-	cfg.DailyFileName = `{{.Date | formatDate "02"}}-{{.Date | formatDate "01"}}-{{.Date | formatDate "2006"}}.log`
+	cfg.DailyFileName = `{{.Date | formatDate "DD"}}-{{.Date | formatDate "MM"}}-{{.Date | formatDate "YYYY"}}.log`
 	date = time.Date(2025, time.December, 25, 0, 0, 0, 0, time.UTC)
 		filePath, _, err = CreateDailyJournalFile(cfg, date, nil, nil)
 	    	assert.NoError(t, err)
@@ -85,7 +85,7 @@ func TestCreateDailyJournalFile(t *testing.T) {
 	// Test case 7: Daily template is applied
 	cfg = config.DefaultConfig()
 	cfg.JournalDir = tmpDir
-	cfg.DailyTemplate = "# {{.Date | formatDate \"2006-01-02\"}} - My Daily Log\n\n[SUMMARY_PLACEHOLDER]\n\n## LOG\n"
+	cfg.DailyTemplate = "# {{.Date | formatDate \"YYYY-MM-DD\"}} - My Daily Log\n\n[SUMMARY_PLACEHOLDER]\n\n## LOG\n"
 	    date = time.Date(2025, time.October, 26, 0, 0, 0, 0, time.UTC)
 	    		filePath, _, err = CreateDailyJournalFile(cfg, date, nil, nil)
 	    	    	assert.NoError(t, err)
@@ -115,7 +115,7 @@ func TestAppendToLog(t *testing.T) {
 	tmpDir := t.TempDir()
 	cfg := config.DefaultConfig()
 	cfg.JournalDir = tmpDir
-	cfg.DailyTemplate = "# {{.Date | formatDate \"2006-01-02\"}} - My Daily Log\n\n[SUMMARY_PLACEHOLDER]\n\n## LOG\n"
+	cfg.DailyTemplate = "# {{.Date | formatDate \"YYYY-MM-DD\"}} - My Daily Log\n\n[SUMMARY_PLACEHOLDER]\n\n## LOG\n"
 	date := time.Date(2025, time.October, 26, 0, 0, 0, 0, time.UTC)
 
 	filePath, _, err := CreateDailyJournalFile(cfg, date, nil, nil)
@@ -279,7 +279,7 @@ func TestListJournalFilesByPeriod(t *testing.T) {
 
 	cfg := config.DefaultConfig()
 	cfg.JournalDir = tmpDir
-	cfg.DailyFileName = "{{.Date | formatDate \"2006-01-02\"}}.md"
+	cfg.DailyFileName = "{{.Date | formatDate \"YYYY-MM-DD\"}}.md"
 
 	// Create some dummy journal files
 	createDummyFile := func(date time.Time) string {
@@ -558,8 +558,8 @@ func TestEmbedOneLineNotes(t *testing.T) {
 
 	cfg := config.DefaultConfig()
 	cfg.JournalDir = tmpDir
-	cfg.DailyFileName = "{{.Date | formatDate \"2006-01-02\"}}.md"
-	cfg.DailyTemplate = "# {{.Date | formatDate \"Jan 02 2006 Monday\"}}\n\n{{.Summary}}\n\n## LOG\n"
+	cfg.DailyFileName = "{{.Date | formatDate \"YYYY-MM-DD\"}}.md"
+	cfg.DailyTemplate = "# {{.Date | formatDate \"MMM DD YYYY dddd\"}}\n\n{{.Summary}}\n\n## LOG\n"
 
 	// Create a dummy daily journal file
 	date := time.Date(2025, time.September, 20, 0, 0, 0, 0, time.UTC)

--- a/pkg/oneline/oneline_test.go
+++ b/pkg/oneline/oneline_test.go
@@ -17,8 +17,8 @@ func TestGetPastSummaries(t *testing.T) {
 
 	cfg := config.DefaultConfig()
 	cfg.JournalDir = tmpDir
-	cfg.DailyFileName = "{{.Date | formatDate \"2006-01-02\"}}.md"
-	cfg.DailyTemplate = "# {{.Date | formatDate \"Jan 02 2006 Monday\"}}\n\n{{.Summary}}\n\n## LOG\n"
+	cfg.DailyFileName = "{{.Date | formatDate \"YYYY-MM-DD\"}}.md"
+	cfg.DailyTemplate = "# {{.Date | formatDate \"MMM DD YYYY dddd\"}}\n\n{{.Summary}}\n\n## LOG\n"
 
 	// Helper to create dummy journal files
 	createDummyJournalFile := func(date time.Time, summary string) string {
@@ -60,7 +60,7 @@ func TestGetPastSummariesWithFrontmatter(t *testing.T) {
 
 	cfg := config.DefaultConfig()
 	cfg.JournalDir = tmpDir
-	cfg.DailyFileName = "{{.Date | formatDate \"2006-01-02\"}}.md"
+	cfg.DailyFileName = "{{.Date | formatDate \"YYYY-MM-DD\"}}.md"
 
 	// Helper to create journal files with YAML frontmatter
 	createFrontmatterFile := func(date time.Time, summary string) {

--- a/pkg/review/review_test.go
+++ b/pkg/review/review_test.go
@@ -30,8 +30,8 @@ func TestReviewWeek(t *testing.T) {
 
 	cfg := config.DefaultConfig()
 	cfg.JournalDir = tmpDir
-	cfg.DailyFileName = "{{.Date | formatDate \"2006-01-02\"}}.md"
-	cfg.DailyTemplate = "# {{.Date | formatDate \"Jan 02 2006 Monday\"}}\n\n{{.Summary}}\n\n## LOG\n"
+	cfg.DailyFileName = "{{.Date | formatDate \"YYYY-MM-DD\"}}.md"
+	cfg.DailyTemplate = "# {{.Date | formatDate \"MMM DD YYYY dddd\"}}\n\n{{.Summary}}\n\n## LOG\n"
 
 	// Create dummy journal files for a specific week (e.g., week 38, 2025)
 	createDummyJournalFile := func(date time.Time, summary string) string {
@@ -173,8 +173,8 @@ func TestReviewMonth(t *testing.T) {
 
 	cfg := config.DefaultConfig()
 	cfg.JournalDir = tmpDir
-	cfg.DailyFileName = "{{.Date | formatDate \"2006-01-02\"}}" + ".md"
-	cfg.DailyTemplate = "# {{.Date | formatDate \"Jan 02 2006 Monday\"}}\n\n{{.Summary}}\n\n## LOG\n"
+	cfg.DailyFileName = "{{.Date | formatDate \"YYYY-MM-DD\"}}" + ".md"
+	cfg.DailyTemplate = "# {{.Date | formatDate \"MMM DD YYYY dddd\"}}\n\n{{.Summary}}\n\n## LOG\n"
 
 	// Create dummy journal files for a specific month (e.g., September 2025)
 	createDummyJournalFile := func(date time.Time, summary string) string {
@@ -308,8 +308,8 @@ func TestReviewYear(t *testing.T) {
 
 	cfg := config.DefaultConfig()
 	cfg.JournalDir = tmpDir
-	cfg.DailyFileName = "{{.Date | formatDate \"2006-01-02\"}}" + ".md"
-	cfg.DailyTemplate = "# {{.Date | formatDate \"Jan 02 2006 Monday\"}}\n\n{{.Summary}}\n\n## LOG\n"
+	cfg.DailyFileName = "{{.Date | formatDate \"YYYY-MM-DD\"}}" + ".md"
+	cfg.DailyTemplate = "# {{.Date | formatDate \"MMM DD YYYY dddd\"}}\n\n{{.Summary}}\n\n## LOG\n"
 
 	// Create dummy journal files for a specific year (e.g., 2025)
 	createDummyJournalFile := func(date time.Time, summary string) string {

--- a/pkg/template/template.go
+++ b/pkg/template/template.go
@@ -3,9 +3,70 @@ package template
 import (
 	"bytes"
 	"fmt"
+	"strings"
 	"text/template"
 	"time"
 )
+
+// obsidianToGoFormat converts an Obsidian/Moment.js date format string to a Go time format string.
+// Supported tokens: YYYY, YY, MMMM, MMM, MM, M, DD, D, dddd, ddd, HH, hh, h, mm, m, ss, s, A, a
+// Use [text] for literal text that should not be interpreted as tokens.
+func obsidianToGoFormat(format string) string {
+	// Token mapping ordered by length (longest first) to avoid partial matches
+	tokens := []struct {
+		token string
+		goFmt string
+	}{
+		{"YYYY", "2006"},
+		{"YY", "06"},
+		{"MMMM", "January"},
+		{"MMM", "Jan"},
+		{"MM", "01"},
+		{"M", "1"},
+		{"DD", "02"},
+		{"D", "2"},
+		{"dddd", "Monday"},
+		{"ddd", "Mon"},
+		{"HH", "15"},
+		{"hh", "03"},
+		{"h", "3"},
+		{"mm", "04"},
+		{"m", "4"},
+		{"ss", "05"},
+		{"s", "5"},
+		{"A", "PM"},
+		{"a", "pm"},
+	}
+
+	var result strings.Builder
+	i := 0
+	for i < len(format) {
+		// Handle escaped text in brackets [text]
+		if format[i] == '[' {
+			end := strings.IndexByte(format[i+1:], ']')
+			if end != -1 {
+				result.WriteString(format[i+1 : i+1+end])
+				i += end + 2
+				continue
+			}
+		}
+
+		matched := false
+		for _, t := range tokens {
+			if strings.HasPrefix(format[i:], t.token) {
+				result.WriteString(t.goFmt)
+				i += len(t.token)
+				matched = true
+				break
+			}
+		}
+		if !matched {
+			result.WriteByte(format[i])
+			i++
+		}
+	}
+	return result.String()
+}
 
 // TemplateData holds the data available for templating.
 type TemplateData struct {
@@ -21,10 +82,10 @@ func Render(templateString string, data TemplateData) (string, error) {
 	// Create a new template and add custom functions
 	tmpl := template.New("logbook_template").Funcs(template.FuncMap{
 		"formatDate": func(format string, date time.Time) string {
-			return date.Format(format)
+			return date.Format(obsidianToGoFormat(format))
 		},
 		"formatTime": func(format string, t time.Time) string {
-			return t.Format(format)
+			return t.Format(obsidianToGoFormat(format))
 		},
 	})
 

--- a/pkg/template/template_test.go
+++ b/pkg/template/template_test.go
@@ -12,14 +12,14 @@ func TestRender(t *testing.T) {
 	data := TemplateData{Date: date}
 
 	// Test case 1: Basic date formatting
-	templateString := "Today is {{.Date | formatDate \"2006-01-02\"}}."
+	templateString := "Today is {{.Date | formatDate \"YYYY-MM-DD\"}}."
 	expected := "Today is 2025-09-18."
 	result, err := Render(templateString, data)
 	assert.NoError(t, err)
 	assert.Equal(t, expected, result)
 
 	// Test case 2: More complex date formatting
-	templateString = "{{.Date | formatDate \"Jan 02 2006 Monday\"}}"
+	templateString = "{{.Date | formatDate \"MMM DD YYYY dddd\"}}"
 	expected = "Sep 18 2025 Thursday"
 	result, err = Render(templateString, data)
 	assert.NoError(t, err)
@@ -37,4 +37,34 @@ func TestRender(t *testing.T) {
 	result, err = Render(templateString, data)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "function \"invalidFunc\" not defined")
+}
+
+func TestObsidianToGoFormat(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{"ISO date", "YYYY-MM-DD", "2006-01-02"},
+		{"date with month name", "MMM DD YYYY dddd", "Jan 02 2006 Monday"},
+		{"time 24h", "HH:mm", "15:04"},
+		{"time 12h with AM/PM", "hh:mm A", "03:04 PM"},
+		{"time with seconds", "HH:mm:ss", "15:04:05"},
+		{"full date verbose", "dddd, MMMM D, YYYY", "Monday, January 2, 2006"},
+		{"2-digit year", "YY-MM-DD", "06-01-02"},
+		{"month/day without leading zero", "M/D/YYYY", "1/2/2006"},
+		{"escaped text", "YYYY [year] MM [month]", "2006 year 01 month"},
+		{"no tokens", "--- / :", "--- / :"},
+		{"separators only", "-/: ", "-/: "},
+		{"full month name", "MMMM", "January"},
+		{"abbreviated weekday", "ddd", "Mon"},
+		{"lowercase am/pm", "hh:mm a", "03:04 pm"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := obsidianToGoFormat(tt.input)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
 }


### PR DESCRIPTION
## Summary
This PR adds support for Obsidian/Moment.js date format tokens (e.g., `YYYY-MM-DD`, `HH:mm`) in template date formatting, replacing Go's reference-time format strings. This makes the configuration more intuitive for users familiar with Obsidian or Moment.js conventions.

## Key Changes

- **New `obsidianToGoFormat()` function** in `pkg/template/template.go`:
  - Converts Obsidian/Moment.js format tokens to Go's time format strings
  - Supports 19 common tokens: `YYYY`, `YY`, `MMMM`, `MMM`, `MM`, `M`, `DD`, `D`, `dddd`, `ddd`, `HH`, `hh`, `h`, `mm`, `m`, `ss`, `s`, `A`, `a`
  - Handles escaped literal text using `[text]` bracket syntax
  - Processes tokens in order of length (longest first) to avoid partial matches

- **Updated template functions**:
  - `formatDate` and `formatTime` now call `obsidianToGoFormat()` to convert user-provided format strings before passing to Go's `time.Format()`

- **Updated default configuration** in `pkg/config/config.go`:
  - `DailyFileName`: `"{{.Date | formatDate \"YYYY-MM-DD\"}}.md"`
  - `DailyTemplate`: Uses `"MMM DD YYYY dddd"` instead of `"Jan 02 2006 Monday"`
  - `LogEntryTemplate`: Uses `"HH:mm"` instead of `"15:04"`
  - `OneLineTemplate`: Uses `"YYYY-MM-DD"` instead of `"2006-01-02"`

- **Comprehensive test coverage**:
  - Added `TestObsidianToGoFormat()` with 14 test cases covering various format combinations
  - Updated all existing tests to use new Obsidian format tokens
  - Tests verify ISO dates, time formats, escaped text, and edge cases

- **Documentation updates** in `CLAUDE.md`:
  - Documented supported tokens and bracket escape syntax
  - Updated examples to use new format token style

## Implementation Details

The conversion function uses a token mapping ordered by length to prevent issues like `MM` matching before `MMMM`. The implementation handles escaped text in brackets by detecting `[` characters and extracting content until the closing `]`, allowing users to include literal text that shouldn't be interpreted as format tokens.

All configuration files and tests have been updated to use the new format consistently, ensuring a smooth user experience across the entire application.

https://claude.ai/code/session_01K3LyDLnNuQdzA2pM3tuB6C