### PR TITLE
Improve title detection to handle malformed frontmatter robustly

### DIFF
--- a/pkg/journal/journal.go
+++ b/pkg/journal/journal.go
@@ -310,6 +310,70 @@ func skipFrontmatter(lines []string) int {
 	return 0 // Unclosed frontmatter, treat as no frontmatter
 }
 
+// isSectionHeader reports whether a trimmed line is a markdown heading
+// at any level whose first word matches the given section name (e.g. "LOG"
+// matches both "# LOG" and "## LOG ...").
+func isSectionHeader(trimmed, name string) bool {
+	if !strings.HasPrefix(trimmed, "#") {
+		return false
+	}
+	rest := strings.TrimLeft(trimmed, "#")
+	if rest == trimmed {
+		return false // Not a heading (no leading #)
+	}
+	rest = strings.TrimLeft(rest, " \t")
+	return rest == name || strings.HasPrefix(rest, name+" ") || strings.HasPrefix(rest, name+"\t")
+}
+
+// isLogOrOneLineSection reports whether a trimmed line marks the LOG or
+// One-line note section, regardless of heading level.
+func isLogOrOneLineSection(trimmed string) bool {
+	return isSectionHeader(trimmed, "LOG") || isSectionHeader(trimmed, "One-line note")
+}
+
+// findTitleLine returns the index of the title line: the first markdown
+// heading line that isn't a known section marker ("LOG" / "One-line note").
+// Leading blank lines and YAML frontmatter (delimited by "---") are skipped.
+// If frontmatter is unclosed or malformed, the scan continues line-by-line
+// until a heading is found, so metadata can never be mistaken for the title.
+// Returns -1 if no title is found.
+func findTitleLine(lines []string) int {
+	i := 0
+	// Skip leading blank lines
+	for i < len(lines) && strings.TrimSpace(lines[i]) == "" {
+		i++
+	}
+	// Skip well-formed YAML frontmatter
+	if i < len(lines) && strings.TrimSpace(lines[i]) == "---" {
+		for j := i + 1; j < len(lines); j++ {
+			if strings.TrimSpace(lines[j]) == "---" {
+				i = j + 1
+				break
+			}
+		}
+	}
+	// Find the first markdown heading line that is the title.
+	// If frontmatter was unclosed, this scan will safely walk past metadata
+	// (which uses YAML "key: value" lines, not markdown headings).
+	for ; i < len(lines); i++ {
+		trimmed := strings.TrimSpace(lines[i])
+		if !strings.HasPrefix(trimmed, "#") {
+			continue
+		}
+		// Section markers are not the title.
+		if isLogOrOneLineSection(trimmed) {
+			return -1
+		}
+		// Must be an actual heading ("# Something"), not a hashtag or "#word".
+		rest := strings.TrimLeft(trimmed, "#")
+		if !strings.HasPrefix(rest, " ") && !strings.HasPrefix(rest, "\t") {
+			continue
+		}
+		return i
+	}
+	return -1
+}
+
 // ExtractSummary reads a journal file and returns its first paragraph as the summary.
 func ExtractSummary(filePath string) (string, error) {
 	content, err := os.ReadFile(filePath)
@@ -322,18 +386,20 @@ func ExtractSummary(filePath string) (string, error) {
 
 	lines := strings.Split(string(content), "\n")
 
-	// Skip YAML frontmatter if present
-	startLine := skipFrontmatter(lines)
+	// Locate the title line robustly (skips frontmatter and leading blanks).
+	titleIdx := findTitleLine(lines)
+	if titleIdx < 0 {
+		return "", nil
+	}
 
 	// The first paragraph after the title and before the "LOG" chapter is considered the summary.
-	// Skip the title line (first line after frontmatter)
 	var summaryLines []string
 	readingSummary := false
 
-	for i := startLine + 1; i < len(lines); i++ {
+	for i := titleIdx + 1; i < len(lines); i++ {
 		trimmedLine := strings.TrimSpace(lines[i])
 
-		if strings.HasPrefix(trimmedLine, "# LOG") || strings.HasPrefix(trimmedLine, "# One-line note") {
+		if isLogOrOneLineSection(trimmedLine) {
 			break // Reached the LOG or One-line note section, stop reading summary
 		}
 

--- a/pkg/journal/journal_test.go
+++ b/pkg/journal/journal_test.go
@@ -488,6 +488,67 @@ func TestExtractSummaryWithFrontmatter(t *testing.T) {
 	assert.Equal(t, "Summary here.", summary)
 }
 
+// TestExtractSummaryRobustEdgeCases verifies that ExtractSummary never picks
+// up YAML metadata as the summary, even when frontmatter is malformed or the
+// file layout has unexpected whitespace.
+func TestExtractSummaryRobustEdgeCases(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	type tc struct {
+		name    string
+		content string
+		want    string
+	}
+	cases := []tc{
+		{
+			name:    "user reported scenario - blank line between frontmatter and title",
+			content: "---\nsome metadata\n---\n\n# 2024-04-12\n<summary>\n",
+			want:    "<summary>",
+		},
+		{
+			name:    "leading blank line before frontmatter",
+			content: "\n---\nkey: val\n---\n# 2024-01-01\nMy summary\n\n# LOG\n",
+			want:    "My summary",
+		},
+		{
+			name:    "unclosed frontmatter must not leak metadata",
+			content: "---\nfoo: bar\nbaz: qux\n# 2024-01-01\nMy summary\n",
+			want:    "My summary",
+		},
+		{
+			name:    "obsidian multiline tag list",
+			content: "---\ntags:\n  - daily\n  - work\ncreated: 2024\n---\n# 2024-01-01\nMy summary\n\n# LOG\n",
+			want:    "My summary",
+		},
+		{
+			name:    "CRLF line endings",
+			content: "---\r\nkey: val\r\n---\r\n# 2024-04-12\r\nMy summary\r\n\r\n# LOG\r\n",
+			want:    "My summary",
+		},
+		{
+			name:    "frontmatter only - no title",
+			content: "---\nfoo: bar\n---\n",
+			want:    "",
+		},
+		{
+			name:    "no real title, only LOG section",
+			content: "---\nfoo: bar\n---\n# LOG\n10:00 entry\n",
+			want:    "",
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			path := filepath.Join(tmpDir, strings.ReplaceAll(c.name, " ", "_")+".md")
+			err := os.WriteFile(path, []byte(c.content), 0644)
+			assert.NoError(t, err)
+			got, err := ExtractSummary(path)
+			assert.NoError(t, err)
+			assert.Equal(t, c.want, got)
+		})
+	}
+}
+
 func TestGenerateSummaryIfMissingWithFrontmatter(t *testing.T) {
 	tmpDir := t.TempDir()
 

--- a/pkg/oneline/oneline.go
+++ b/pkg/oneline/oneline.go
@@ -182,6 +182,70 @@ func skipFrontmatter(lines []string) int {
 	return 0 // Unclosed frontmatter, treat as no frontmatter
 }
 
+// isSectionHeader reports whether a trimmed line is a markdown heading
+// at any level whose first word matches the given section name (e.g. "LOG"
+// matches both "# LOG" and "## LOG ...").
+func isSectionHeader(trimmed, name string) bool {
+	if !strings.HasPrefix(trimmed, "#") {
+		return false
+	}
+	rest := strings.TrimLeft(trimmed, "#")
+	if rest == trimmed {
+		return false
+	}
+	rest = strings.TrimLeft(rest, " \t")
+	return rest == name || strings.HasPrefix(rest, name+" ") || strings.HasPrefix(rest, name+"\t")
+}
+
+// isLogOrOneLineSection reports whether a trimmed line marks the LOG or
+// One-line note section, regardless of heading level.
+func isLogOrOneLineSection(trimmed string) bool {
+	return isSectionHeader(trimmed, "LOG") || isSectionHeader(trimmed, "One-line note")
+}
+
+// findTitleLine returns the index of the title line: the first markdown
+// heading line that isn't a known section marker ("LOG" / "One-line note").
+// Leading blank lines and YAML frontmatter (delimited by "---") are skipped.
+// If frontmatter is unclosed or malformed, the scan continues line-by-line
+// until a heading is found, so metadata can never be mistaken for the title.
+// Returns -1 if no title is found.
+func findTitleLine(lines []string) int {
+	i := 0
+	// Skip leading blank lines
+	for i < len(lines) && strings.TrimSpace(lines[i]) == "" {
+		i++
+	}
+	// Skip well-formed YAML frontmatter
+	if i < len(lines) && strings.TrimSpace(lines[i]) == "---" {
+		for j := i + 1; j < len(lines); j++ {
+			if strings.TrimSpace(lines[j]) == "---" {
+				i = j + 1
+				break
+			}
+		}
+	}
+	// Find the first markdown heading line that is the title.
+	// If frontmatter was unclosed, this scan will safely walk past metadata
+	// (which uses YAML "key: value" lines, not markdown headings).
+	for ; i < len(lines); i++ {
+		trimmed := strings.TrimSpace(lines[i])
+		if !strings.HasPrefix(trimmed, "#") {
+			continue
+		}
+		// Section markers are not the title.
+		if isLogOrOneLineSection(trimmed) {
+			return -1
+		}
+		// Must be an actual heading ("# Something"), not a hashtag or "#word".
+		rest := strings.TrimLeft(trimmed, "#")
+		if !strings.HasPrefix(rest, " ") && !strings.HasPrefix(rest, "\t") {
+			continue
+		}
+		return i
+	}
+	return -1
+}
+
 // extractSummary reads a journal file and returns its first paragraph as the summary.
 func extractSummary(filePath string) (string, error) {
 	content, err := os.ReadFile(filePath)
@@ -194,18 +258,20 @@ func extractSummary(filePath string) (string, error) {
 
 	lines := strings.Split(string(content), "\n")
 
-	// Skip YAML frontmatter if present
-	startLine := skipFrontmatter(lines)
+	// Locate the title line robustly (skips frontmatter and leading blanks).
+	titleIdx := findTitleLine(lines)
+	if titleIdx < 0 {
+		return "", nil
+	}
 
 	// The first paragraph after the title and before the "LOG" chapter is considered the summary.
-	// Skip the title line (first line after frontmatter)
 	var summaryLines []string
 	readingSummary := false
 
-	for i := startLine + 1; i < len(lines); i++ {
+	for i := titleIdx + 1; i < len(lines); i++ {
 		trimmedLine := strings.TrimSpace(lines[i])
 
-		if strings.HasPrefix(trimmedLine, "# LOG") || strings.HasPrefix(trimmedLine, "# One-line note") {
+		if isLogOrOneLineSection(trimmedLine) {
 			break // Reached the LOG or One-line note section, stop reading summary
 		}
 

--- a/pkg/oneline/oneline_test.go
+++ b/pkg/oneline/oneline_test.go
@@ -3,6 +3,7 @@ package oneline
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -53,6 +54,58 @@ func TestGetPastSummaries(t *testing.T) {
 	actualSummaries, err := GetPastSummaries(cfg, targetDate)
 	assert.NoError(t, err)
 	assert.Equal(t, expectedSummaries, actualSummaries)
+}
+
+// TestExtractSummaryRobustEdgeCases verifies that the oneline summary
+// extractor never returns YAML metadata as the summary, even when the
+// frontmatter is malformed or the layout has unexpected whitespace.
+func TestExtractSummaryRobustEdgeCases(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	type tc struct {
+		name    string
+		content string
+		want    string
+	}
+	cases := []tc{
+		{
+			// User-reported bug: blank line between closing "---" and title
+			name:    "blank line between frontmatter and title",
+			content: "---\nsome metadata\n---\n\n# 2024-04-12\n<summary>\n",
+			want:    "<summary>",
+		},
+		{
+			name:    "leading blank line before frontmatter",
+			content: "\n---\nkey: val\n---\n# 2024\nMy summary\n\n# LOG\n",
+			want:    "My summary",
+		},
+		{
+			name:    "unclosed frontmatter must not leak metadata",
+			content: "---\nfoo: bar\nbaz: qux\n# 2024\nMy summary\n",
+			want:    "My summary",
+		},
+		{
+			name:    "obsidian multiline tags",
+			content: "---\ntags:\n  - daily\n  - work\n---\n# 2024\nMy summary\n\n# LOG\n",
+			want:    "My summary",
+		},
+		{
+			name:    "frontmatter only, no title",
+			content: "---\nfoo: bar\n---\n",
+			want:    "",
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			path := filepath.Join(tmpDir, strings.ReplaceAll(c.name, " ", "_")+".md")
+			err := os.WriteFile(path, []byte(c.content), 0644)
+			assert.NoError(t, err)
+			got, err := extractSummary(path)
+			assert.NoError(t, err)
+			assert.Equal(t, c.want, got)
+		})
+	}
 }
 
 func TestGetPastSummariesWithFrontmatter(t *testing.T) {


### PR DESCRIPTION
## Summary
This PR fixes a bug where `ExtractSummary` could incorrectly extract YAML metadata as the summary when frontmatter is malformed or has unexpected whitespace. The fix introduces robust title detection that safely handles edge cases like unclosed frontmatter, blank lines between frontmatter and content, and various YAML formats.

## Key Changes
- **New helper functions** (`isSectionHeader`, `isLogOrOneLineSection`, `findTitleLine`):
  - `isSectionHeader`: Detects markdown headings at any level matching a section name (e.g., "LOG", "One-line note")
  - `isLogOrOneLineSection`: Checks if a line is a known section marker
  - `findTitleLine`: Robustly locates the first actual title by skipping frontmatter and leading blanks, then finding the first markdown heading that isn't a section marker

- **Updated `ExtractSummary` logic** in both `pkg/journal/journal.go` and `pkg/oneline/oneline.go`:
  - Replaced simple `skipFrontmatter` call with `findTitleLine` for more robust title detection
  - Replaced hardcoded `"# LOG"` and `"# One-line note"` checks with `isLogOrOneLineSection` calls
  - Now handles section markers at any heading level (not just `#`)

- **Comprehensive test coverage**:
  - Added `TestExtractSummaryRobustEdgeCases` in both test files
  - Tests cover: blank lines between frontmatter and title, leading blank lines, unclosed frontmatter, multiline YAML tags, CRLF line endings, and files with no title

## Notable Implementation Details
- The `findTitleLine` function safely handles unclosed frontmatter by continuing line-by-line scanning after the frontmatter block, ensuring YAML metadata (which uses "key: value" syntax, not markdown headings) is never mistaken for a title
- Section markers are explicitly excluded from being treated as titles, preventing "# LOG" or "# One-line note" from being extracted as summaries
- Heading validation ensures only proper markdown headings (with space/tab after `#`) are considered, not hashtags or malformed syntax

https://claude.ai/code/session_012ADXUGfr7wCrJx6bPoam1M