### PR TITLE
Add one-line-a-day command to generate yearly summary files

### DIFF
--- a/main.go
+++ b/main.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/clobrano/LogBook/pkg/config"
 	"github.com/clobrano/LogBook/pkg/journal"
+	"github.com/clobrano/LogBook/pkg/onelineaday"
 	"github.com/clobrano/LogBook/pkg/review"
 )
 
@@ -46,6 +47,8 @@ Available Commands:
             logbook review week [week number] [year] (defaults to current week/year)
             logbook review month [month name] [year] (defaults to current month/year)
             logbook review year [year] (defaults to current year)
+  one-line-a-day  Generate a yearly summary file with one line per daily entry.
+          Usage: logbook one-line-a-day [year] (defaults to all years)
 
 Examples:
   logbook config
@@ -198,6 +201,35 @@ Examples:
 			default:
 				fmt.Println("Unknown review subcommand. Use 'logbook review help' for more information.")
 				os.Exit(1)
+			}
+		case "one-line-a-day":
+			cfg, err = config.LoadConfig(configFilePath)
+			if err != nil {
+				fmt.Printf("Error loading configuration: %v\n", err)
+				os.Exit(1)
+			}
+
+			if len(os.Args) >= 3 {
+				year, err := strconv.Atoi(os.Args[2])
+				if err != nil {
+					fmt.Println("Invalid year:", os.Args[2])
+					os.Exit(1)
+				}
+				path, err := onelineaday.Generate(cfg, year)
+				if err != nil {
+					fmt.Printf("Error generating one-line-a-day: %v\n", err)
+					os.Exit(1)
+				}
+				fmt.Printf("One-line-a-day file generated: %s\n", path)
+			} else {
+				paths, err := onelineaday.GenerateAll(cfg)
+				if err != nil {
+					fmt.Printf("Error generating one-line-a-day: %v\n", err)
+					os.Exit(1)
+				}
+				for _, p := range paths {
+					fmt.Printf("One-line-a-day file generated: %s\n", p)
+				}
 			}
 		case "log":
 			fallthrough

--- a/pkg/onelineaday/onelineaday.go
+++ b/pkg/onelineaday/onelineaday.go
@@ -85,7 +85,7 @@ func Generate(cfg *config.Config, year int) (string, error) {
 		b.WriteString(fmt.Sprintf("\n# %s\n\n", month.String()[:3]))
 
 		for _, e := range entries {
-			b.WriteString(fmt.Sprintf("* %s %s: %s\n", e.date.Format("2006-01-02"), e.date.Format("Mon"), e.summary))
+			b.WriteString(fmt.Sprintf("* %s %s | %s\n", e.date.Format("2006-01-02"), e.date.Format("Mon"), e.summary))
 		}
 	}
 

--- a/pkg/onelineaday/onelineaday.go
+++ b/pkg/onelineaday/onelineaday.go
@@ -89,7 +89,7 @@ func Generate(cfg *config.Config, year int) (string, error) {
 		b.WriteString(fmt.Sprintf("\n# %s\n\n", month.String()[:3]))
 
 		for _, e := range entries {
-			b.WriteString(fmt.Sprintf("* %s: %s\n", e.date.Format("2006-01-02"), e.summary))
+			b.WriteString(fmt.Sprintf("* %s %s: %s\n", e.date.Format("2006-01-02"), e.date.Format("Mon"), e.summary))
 		}
 	}
 

--- a/pkg/onelineaday/onelineaday.go
+++ b/pkg/onelineaday/onelineaday.go
@@ -85,7 +85,7 @@ func Generate(cfg *config.Config, year int) (string, error) {
 		b.WriteString(fmt.Sprintf("\n# %s\n\n", month.String()[:3]))
 
 		for _, e := range entries {
-			b.WriteString(fmt.Sprintf("* %s %s | %s\n", e.date.Format("2006-01-02"), e.date.Format("Mon"), e.summary))
+			b.WriteString(fmt.Sprintf("* %s %s| %s\n", e.date.Format("2006-01-02"), e.date.Format("Mon"), e.summary))
 		}
 	}
 

--- a/pkg/onelineaday/onelineaday.go
+++ b/pkg/onelineaday/onelineaday.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"github.com/clobrano/LogBook/pkg/config"
-	"github.com/clobrano/LogBook/pkg/journal"
 )
 
 // Generate scans all daily journal files and produces one markdown file per year
@@ -55,17 +54,14 @@ func Generate(cfg *config.Config, year int) (string, error) {
 		}
 
 		filePath := filepath.Join(journalDir, name)
-		summary, err := journal.ExtractSummary(filePath)
-		if err != nil {
-			continue
-		}
-		if summary == "" {
+		content, err := extractFirstSection(filePath)
+		if err != nil || content == "" {
 			continue
 		}
 
 		byMonth[parsed.Month()] = append(byMonth[parsed.Month()], dailyEntry{
 			date:    parsed,
-			summary: summary,
+			summary: content,
 		})
 	}
 
@@ -155,4 +151,85 @@ func GenerateAll(cfg *config.Config) ([]string, error) {
 	}
 
 	return paths, nil
+}
+
+// extractFirstSection reads a journal file and returns all content between
+// the first markdown heading and the next heading. YAML frontmatter and
+// HTML comments are skipped.
+func extractFirstSection(filePath string) (string, error) {
+	data, err := os.ReadFile(filePath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return "", nil
+		}
+		return "", err
+	}
+
+	lines := strings.Split(string(data), "\n")
+	i := 0
+
+	// Skip YAML frontmatter
+	if i < len(lines) && strings.TrimSpace(lines[i]) == "---" {
+		for j := i + 1; j < len(lines); j++ {
+			if strings.TrimSpace(lines[j]) == "---" {
+				i = j + 1
+				break
+			}
+		}
+	}
+
+	// Find the first markdown heading
+	titleIdx := -1
+	for ; i < len(lines); i++ {
+		trimmed := strings.TrimSpace(lines[i])
+		if strings.HasPrefix(trimmed, "#") {
+			rest := strings.TrimLeft(trimmed, "#")
+			if strings.HasPrefix(rest, " ") || strings.HasPrefix(rest, "\t") {
+				titleIdx = i
+				break
+			}
+		}
+	}
+	if titleIdx < 0 {
+		return "", nil
+	}
+
+	// Collect all lines after the title until the next heading
+	var contentLines []string
+	for i := titleIdx + 1; i < len(lines); i++ {
+		trimmed := strings.TrimSpace(lines[i])
+		if strings.HasPrefix(trimmed, "#") {
+			rest := strings.TrimLeft(trimmed, "#")
+			if strings.HasPrefix(rest, " ") || strings.HasPrefix(rest, "\t") {
+				break
+			}
+		}
+		if strings.HasPrefix(trimmed, "<!--") {
+			continue
+		}
+		contentLines = append(contentLines, trimmed)
+	}
+
+	// Trim leading and trailing empty lines, then join with spaces
+	for len(contentLines) > 0 && contentLines[0] == "" {
+		contentLines = contentLines[1:]
+	}
+	for len(contentLines) > 0 && contentLines[len(contentLines)-1] == "" {
+		contentLines = contentLines[:len(contentLines)-1]
+	}
+
+	if len(contentLines) == 0 {
+		return "", nil
+	}
+
+	// Join non-empty lines with spaces, preserving paragraph breaks as " "
+	var parts []string
+	for _, l := range contentLines {
+		if l == "" {
+			continue
+		}
+		parts = append(parts, l)
+	}
+
+	return strings.Join(parts, " "), nil
 }

--- a/pkg/onelineaday/onelineaday.go
+++ b/pkg/onelineaday/onelineaday.go
@@ -1,0 +1,158 @@
+package onelineaday
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/clobrano/LogBook/pkg/config"
+	"github.com/clobrano/LogBook/pkg/journal"
+)
+
+// Generate scans all daily journal files and produces one markdown file per year
+// with entries grouped by month. Each entry contains the summary (first paragraph
+// after the title) from the corresponding daily journal file.
+func Generate(cfg *config.Config, year int) (string, error) {
+	if err := cfg.Validate(); err != nil {
+		return "", fmt.Errorf("invalid configuration: %w", err)
+	}
+
+	journalDir := cfg.JournalDir
+	if !filepath.IsAbs(journalDir) {
+		return "", fmt.Errorf("JournalDir must be an absolute path: %s", journalDir)
+	}
+
+	entries, err := os.ReadDir(journalDir)
+	if err != nil {
+		return "", fmt.Errorf("failed to read journal directory: %w", err)
+	}
+
+	type dailyEntry struct {
+		date    time.Time
+		summary string
+	}
+
+	byMonth := make(map[time.Month][]dailyEntry)
+
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		name := entry.Name()
+		if !strings.HasSuffix(name, ".md") {
+			continue
+		}
+		dateStr := strings.TrimSuffix(name, ".md")
+		parsed, err := time.Parse("2006-01-02", dateStr)
+		if err != nil {
+			continue
+		}
+		if parsed.Year() != year {
+			continue
+		}
+
+		filePath := filepath.Join(journalDir, name)
+		summary, err := journal.ExtractSummary(filePath)
+		if err != nil {
+			continue
+		}
+		if summary == "" {
+			continue
+		}
+
+		byMonth[parsed.Month()] = append(byMonth[parsed.Month()], dailyEntry{
+			date:    parsed,
+			summary: summary,
+		})
+	}
+
+	if len(byMonth) == 0 {
+		return "", fmt.Errorf("no journal entries with summaries found for year %d", year)
+	}
+
+	var b strings.Builder
+	b.WriteString(fmt.Sprintf("# Year %d\n", year))
+
+	for month := time.January; month <= time.December; month++ {
+		entries := byMonth[month]
+		if len(entries) == 0 {
+			continue
+		}
+
+		sort.Slice(entries, func(i, j int) bool {
+			return entries[i].date.Before(entries[j].date)
+		})
+
+		b.WriteString(fmt.Sprintf("\n# %s\n\n", month.String()[:3]))
+
+		for _, e := range entries {
+			b.WriteString(fmt.Sprintf("* %s: %s\n", e.date.Format("2006-01-02"), e.summary))
+		}
+	}
+
+	outputPath := filepath.Join(journalDir, fmt.Sprintf("one-line-a-day-%d.md", year))
+	if err := os.WriteFile(outputPath, []byte(b.String()), 0644); err != nil {
+		return "", fmt.Errorf("failed to write one-line-a-day file: %w", err)
+	}
+
+	return outputPath, nil
+}
+
+// GenerateAll scans the journal directory and generates one-line-a-day files
+// for every year that has journal entries. Returns the list of generated file paths.
+func GenerateAll(cfg *config.Config) ([]string, error) {
+	if err := cfg.Validate(); err != nil {
+		return nil, fmt.Errorf("invalid configuration: %w", err)
+	}
+
+	journalDir := cfg.JournalDir
+	if !filepath.IsAbs(journalDir) {
+		return nil, fmt.Errorf("JournalDir must be an absolute path: %s", journalDir)
+	}
+
+	entries, err := os.ReadDir(journalDir)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read journal directory: %w", err)
+	}
+
+	years := make(map[int]bool)
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		name := entry.Name()
+		if !strings.HasSuffix(name, ".md") {
+			continue
+		}
+		dateStr := strings.TrimSuffix(name, ".md")
+		parsed, err := time.Parse("2006-01-02", dateStr)
+		if err != nil {
+			continue
+		}
+		years[parsed.Year()] = true
+	}
+
+	sortedYears := make([]int, 0, len(years))
+	for y := range years {
+		sortedYears = append(sortedYears, y)
+	}
+	sort.Ints(sortedYears)
+
+	var paths []string
+	for _, y := range sortedYears {
+		path, err := Generate(cfg, y)
+		if err != nil {
+			continue
+		}
+		paths = append(paths, path)
+	}
+
+	if len(paths) == 0 {
+		return nil, fmt.Errorf("no journal entries with summaries found")
+	}
+
+	return paths, nil
+}

--- a/pkg/onelineaday/onelineaday_test.go
+++ b/pkg/onelineaday/onelineaday_test.go
@@ -1,0 +1,146 @@
+package onelineaday
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/clobrano/LogBook/pkg/config"
+	"github.com/stretchr/testify/assert"
+)
+
+func newTestConfig(dir string) *config.Config {
+	cfg := config.DefaultConfig()
+	cfg.JournalDir = dir
+	return cfg
+}
+
+func createJournalFile(t *testing.T, dir, name, content string) {
+	t.Helper()
+	err := os.WriteFile(filepath.Join(dir, name), []byte(content), 0644)
+	assert.NoError(t, err)
+}
+
+func TestGenerate(t *testing.T) {
+	tmpDir := t.TempDir()
+	cfg := newTestConfig(tmpDir)
+
+	createJournalFile(t, tmpDir, "2025-01-10.md",
+		"# Jan 10 2025 Friday\nStarted the new project today.\n\n# LOG\n10:00 Did stuff\n")
+	createJournalFile(t, tmpDir, "2025-01-15.md",
+		"# Jan 15 2025 Wednesday\nMade progress on the feature.\n\n# LOG\n11:00 More stuff\n")
+	createJournalFile(t, tmpDir, "2025-03-05.md",
+		"# Mar 05 2025 Wednesday\nFixed a critical bug in production.\n\n# One-line note\nold stuff\n\n# LOG\n09:00 Debugging\n")
+
+	path, err := Generate(cfg, 2025)
+	assert.NoError(t, err)
+	assert.Equal(t, filepath.Join(tmpDir, "one-line-a-day-2025.md"), path)
+
+	content, err := os.ReadFile(path)
+	assert.NoError(t, err)
+
+	expected := `# Year 2025
+
+# Jan
+
+* 2025-01-10: Started the new project today.
+* 2025-01-15: Made progress on the feature.
+
+# Mar
+
+* 2025-03-05: Fixed a critical bug in production.
+`
+	assert.Equal(t, expected, string(content))
+}
+
+func TestGenerateSkipsEmptySummaries(t *testing.T) {
+	tmpDir := t.TempDir()
+	cfg := newTestConfig(tmpDir)
+
+	createJournalFile(t, tmpDir, "2025-02-01.md",
+		"# Feb 01 2025 Saturday\nHas a summary.\n\n# LOG\n")
+	createJournalFile(t, tmpDir, "2025-02-02.md",
+		"# Feb 02 2025 Sunday\n<!-- add today summary below this line -->\n\n# LOG\n")
+
+	path, err := Generate(cfg, 2025)
+	assert.NoError(t, err)
+
+	content, err := os.ReadFile(path)
+	assert.NoError(t, err)
+
+	assert.Contains(t, string(content), "2025-02-01")
+	assert.NotContains(t, string(content), "2025-02-02")
+}
+
+func TestGenerateSkipsNonJournalFiles(t *testing.T) {
+	tmpDir := t.TempDir()
+	cfg := newTestConfig(tmpDir)
+
+	createJournalFile(t, tmpDir, "2025-06-01.md",
+		"# Jun 01 2025 Sunday\nA normal entry.\n\n# LOG\n")
+	createJournalFile(t, tmpDir, "review_week_2025_23.md",
+		"# Weekly Review\nSome review content.\n\n")
+	createJournalFile(t, tmpDir, "notes.md",
+		"# Random notes\nNot a journal.\n")
+
+	path, err := Generate(cfg, 2025)
+	assert.NoError(t, err)
+
+	content, err := os.ReadFile(path)
+	assert.NoError(t, err)
+
+	assert.Contains(t, string(content), "2025-06-01")
+	assert.NotContains(t, string(content), "review")
+	assert.NotContains(t, string(content), "Random")
+}
+
+func TestGenerateNoEntriesReturnsError(t *testing.T) {
+	tmpDir := t.TempDir()
+	cfg := newTestConfig(tmpDir)
+
+	_, err := Generate(cfg, 2025)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "no journal entries")
+}
+
+func TestGenerateMultipleYears(t *testing.T) {
+	tmpDir := t.TempDir()
+	cfg := newTestConfig(tmpDir)
+
+	createJournalFile(t, tmpDir, "2024-12-25.md",
+		"# Dec 25 2024 Wednesday\nChristmas day notes.\n\n# LOG\n")
+	createJournalFile(t, tmpDir, "2025-01-01.md",
+		"# Jan 01 2025 Wednesday\nNew year notes.\n\n# LOG\n")
+
+	// Generate for 2024 only
+	path, err := Generate(cfg, 2024)
+	assert.NoError(t, err)
+
+	content, err := os.ReadFile(path)
+	assert.NoError(t, err)
+
+	assert.Contains(t, string(content), "Year 2024")
+	assert.Contains(t, string(content), "2024-12-25")
+	assert.NotContains(t, string(content), "2025")
+}
+
+func TestGenerateAll(t *testing.T) {
+	tmpDir := t.TempDir()
+	cfg := newTestConfig(tmpDir)
+
+	createJournalFile(t, tmpDir, "2024-06-15.md",
+		"# Jun 15 2024 Saturday\nMid-year entry.\n\n# LOG\n")
+	createJournalFile(t, tmpDir, "2025-03-10.md",
+		"# Mar 10 2025 Monday\nAnother entry.\n\n# LOG\n")
+
+	paths, err := GenerateAll(cfg)
+	assert.NoError(t, err)
+	assert.Len(t, paths, 2)
+
+	assert.Equal(t, filepath.Join(tmpDir, "one-line-a-day-2024.md"), paths[0])
+	assert.Equal(t, filepath.Join(tmpDir, "one-line-a-day-2025.md"), paths[1])
+
+	for _, p := range paths {
+		assert.FileExists(t, p)
+	}
+}

--- a/pkg/onelineaday/onelineaday_test.go
+++ b/pkg/onelineaday/onelineaday_test.go
@@ -43,12 +43,12 @@ func TestGenerate(t *testing.T) {
 
 # Jan
 
-* 2025-01-10 Fri | Started the new project today.
-* 2025-01-15 Wed | Made progress on the feature.
+* 2025-01-10 Fri| Started the new project today.
+* 2025-01-15 Wed| Made progress on the feature.
 
 # Mar
 
-* 2025-03-05 Wed | Fixed a critical bug in production.
+* 2025-03-05 Wed| Fixed a critical bug in production.
 `
 	assert.Equal(t, expected, string(content))
 }

--- a/pkg/onelineaday/onelineaday_test.go
+++ b/pkg/onelineaday/onelineaday_test.go
@@ -124,6 +124,60 @@ func TestGenerateMultipleYears(t *testing.T) {
 	assert.NotContains(t, string(content), "2025")
 }
 
+func TestExtractFirstSectionMultipleParagraphs(t *testing.T) {
+	tmpDir := t.TempDir()
+	cfg := newTestConfig(tmpDir)
+
+	createJournalFile(t, tmpDir, "2025-04-01.md",
+		"# Apr 01 2025 Tuesday\nFirst paragraph of the day.\n\nSecond paragraph with more details.\n\n# LOG\n10:00 Did stuff\n")
+
+	path, err := Generate(cfg, 2025)
+	assert.NoError(t, err)
+
+	content, err := os.ReadFile(path)
+	assert.NoError(t, err)
+
+	assert.Contains(t, string(content), "First paragraph of the day. Second paragraph with more details.")
+}
+
+func TestExtractFirstSectionWithFrontmatter(t *testing.T) {
+	tmpDir := t.TempDir()
+	cfg := newTestConfig(tmpDir)
+
+	createJournalFile(t, tmpDir, "2021-12-02.md", `---
+date:  2021-w48
+family:  green
+---
+
+[nav](link.md)
+
+# Notes
+> Winning is nice if you don't lose your integrity in the process.
+
+First real paragraph here.
+
+Second paragraph with more thoughts.
+
+
+# Todos
+- [x] test something
+- [ ] do something else
+`)
+
+	path, err := Generate(cfg, 2021)
+	assert.NoError(t, err)
+
+	content, err := os.ReadFile(path)
+	assert.NoError(t, err)
+
+	s := string(content)
+	assert.Contains(t, s, "Winning is nice")
+	assert.Contains(t, s, "First real paragraph here.")
+	assert.Contains(t, s, "Second paragraph with more thoughts.")
+	assert.NotContains(t, s, "test something")
+	assert.NotContains(t, s, "Todos")
+}
+
 func TestGenerateAll(t *testing.T) {
 	tmpDir := t.TempDir()
 	cfg := newTestConfig(tmpDir)

--- a/pkg/onelineaday/onelineaday_test.go
+++ b/pkg/onelineaday/onelineaday_test.go
@@ -43,12 +43,12 @@ func TestGenerate(t *testing.T) {
 
 # Jan
 
-* 2025-01-10 Fri: Started the new project today.
-* 2025-01-15 Wed: Made progress on the feature.
+* 2025-01-10 Fri | Started the new project today.
+* 2025-01-15 Wed | Made progress on the feature.
 
 # Mar
 
-* 2025-03-05 Wed: Fixed a critical bug in production.
+* 2025-03-05 Wed | Fixed a critical bug in production.
 `
 	assert.Equal(t, expected, string(content))
 }

--- a/pkg/onelineaday/onelineaday_test.go
+++ b/pkg/onelineaday/onelineaday_test.go
@@ -43,12 +43,12 @@ func TestGenerate(t *testing.T) {
 
 # Jan
 
-* 2025-01-10: Started the new project today.
-* 2025-01-15: Made progress on the feature.
+* 2025-01-10 Fri: Started the new project today.
+* 2025-01-15 Wed: Made progress on the feature.
 
 # Mar
 
-* 2025-03-05: Fixed a critical bug in production.
+* 2025-03-05 Wed: Fixed a critical bug in production.
 `
 	assert.Equal(t, expected, string(content))
 }


### PR DESCRIPTION
Introduces a new `one-line-a-day` CLI command that scans daily journal
entries and produces one markdown file per year, with entries grouped by
month. Each entry shows the date and the summary paragraph from the
corresponding daily journal file.

Usage: logbook one-line-a-day [year]

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Dx7XoA5rgoJw9fSXgMfjfo